### PR TITLE
Resolve a NU1608 warning in the Infrastructure.Tests.csproj

### DIFF
--- a/src/Infrastructure.Tests/Infrastructure.Tests.csproj
+++ b/src/Infrastructure.Tests/Infrastructure.Tests.csproj
@@ -12,14 +12,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Machine.Fakes" Version="2.11.0" />
-    <PackageReference Include="Machine.Fakes.Moq" Version="2.11.0" />
+    <PackageReference Include="Machine.Fakes.Moq" Version="2.10.0" />
     <PackageReference Include="Machine.Specifications" Version="1.0.0" />
-    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.10.1" />
+    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.10.2" />
     <PackageReference Include="Machine.Specifications.Should" Version="1.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Moq" Version="4.16.0" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="SpecFlow" Version="3.7.38" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="SpecFlow" Version="3.9.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi@ArildF, I found a NU1608 warning in the Infrastructure.Tests.csproj:

`Warning NU1608 Detected package version outside of dependency constraint: Machine.Fakes.Moq 2.11.0 requires Moq (>= 4.10.1 && < 4.11.0)，but version Moq 4.16.0 was resolved.`

This fix can remove this warnings from PTB's dependency graph.
Hope the PR can help you.

Best regards,
sucrose